### PR TITLE
Add fetch request and mini form for searching a word

### DIFF
--- a/src/App/App.svelte
+++ b/src/App/App.svelte
@@ -1,12 +1,31 @@
 <script>
-	
 	let greeting = 'Welcome to Sexy Synonyms';
+
+	// const url  = process.env.DICTIONARY_REFERENCES_THESAURUS_URL;
+  // const url = '01672bcc-913a-4964-b9c5-2f4cafa8ca78'
+  let searchResults = [];
+  let searchWord = '';
+  const url = '01672bcc-913a-4964-b9c5-2f4cafa8ca78'
+  
+  const findSynonyms = (async () => {
+    const response = await fetch(`https://www.dictionaryapi.com/api/v3/references/thesaurus/json/${searchWord}?key=${url}`)
+    const data = await response.json();
+    const fullSynonyms = data.map(object => {
+      return object.meta.syns
+    })
+    const returnedWords = await fullSynonyms[0].flat();
+    searchResults = returnedWords;
+    console.log(searchResults)
+  });
+	
 </script>
 
 <main>
 	<h1>Hello, {greeting}!</h1>
 	<p>Use this application to search for a word, you will receive a list of synonyms in button form, 
 		if you click you will get a new list, happy learning!</p>
+	<input type='text' placeholder='Enter A Word' bind:value={searchWord}/>
+	<button on:click={findSynonyms}>Click me</button>
 </main>
 
 <style>


### PR DESCRIPTION
## What does this PR do?
- Adds a method for fetching from the API
- Adds an input and button for for searching
- Hardcodes in the API_KEY

## How to test?
- Pull down the branch `api-call`
- Run `npm I`
- Run `npm run dev`
- Search a word in the input 
- Open your console, there is a log already in there for seeing the returned array

## Issues
- This should close #8 and #4 
- The board has been updated 

## Screenshots:
![Screen Shot 2020-03-02 at 10 53 36 AM](https://user-images.githubusercontent.com/48968224/75703128-149cbf00-5c74-11ea-8ab4-bef67b304a45.png)

## Notes:
- The amount of time spent trying to hide the API_KEY has turned into a long productive struggle and I think it is time to move passed it. I have tried a number of `npm` packages and re structuring the config file but with no luck. Just something to keep an eye on moving forward.

Thanks! 