### PR TITLE
Add wordBtn component with click and display for second fetch

### DIFF
--- a/src/App/App.svelte
+++ b/src/App/App.svelte
@@ -16,7 +16,6 @@
     })
 			const returnedWords = await fullSynonyms[0].flat();
 			searchResults = returnedWords;
-			console.log(searchResults)
   });
 </script>
 
@@ -35,7 +34,6 @@
 <style>
 	main {
 		text-align: center;
-		height: 100vh;
 		padding: 1em;
 		max-width: 240px;
 		margin: 0 auto;

--- a/src/Form/Form.svelte
+++ b/src/Form/Form.svelte
@@ -50,8 +50,9 @@
 
   button:hover {
     border-color: black;
-    color: black;
     background-color: lightcoral;
+    color: black;
+    font-weight: bold;
   }
 
   

--- a/src/WordBtn/WordBtn.svelte
+++ b/src/WordBtn/WordBtn.svelte
@@ -1,0 +1,32 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+
+  const dispatch = createEventDispatcher();
+  export let secondWord;
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    dispatch('getNextSynonym', secondWord)
+  }
+</script>
+
+<button on:click={handleSubmit}>{secondWord}</button>
+
+<style>
+
+  button {
+    cursor: pointer;
+    color: lightcoral;
+    height: 3.5em;
+    font-weight: bold;
+    margin: 1em;
+    width: 28%
+  }
+
+  button:hover {
+    border-color: black;
+    color: black;
+    background-color: lightcoral;
+  }
+
+</style>

--- a/src/WordContainer/WordContainer.svelte
+++ b/src/WordContainer/WordContainer.svelte
@@ -1,14 +1,33 @@
-<script>
+<script>  
+  import WordBtn from '../WordBtn/WordBtn.svelte';
+
+  const url = '01672bcc-913a-4964-b9c5-2f4cafa8ca78';
   export let word;
   export let searchResults;
+
+  const findSynonyms = (async (e) => {
+    word = e.detail;
+    const response = await fetch(`https://www.dictionaryapi.com/api/v3/references/thesaurus/json/${word}?key=${url}`)
+    const data = await response.json();
+    const fullSynonyms = data.map(object => {
+      return object.meta.syns
+    })
+    const returnedWords = await fullSynonyms[0].flat();
+    searchResults = returnedWords;
+  });
+
+  const handleSubmit = e => {
+    e.preventDefault()
+    findSynonyms()
+  }
 
 </script>
 
 
 <section >  
-  <h2>{ word }</h2>
-    {#each searchResults as searchResults}
-      <button type='button'>{searchResults}</button>
+  <h2>SYNONYMS FOR: <span>{word}</span></h2>
+    {#each searchResults as secondWord}
+      <WordBtn on:getNextSynonym={findSynonyms} secondWord={secondWord}/>
     {/each}
 </section>
 
@@ -19,11 +38,12 @@
     justify-content: center;
     flex-direction: row;
     flex-wrap: wrap;
+    overflow: scroll;
     width: 100%;
   }
 
   h2 {
-    font-size: 2.5em;
+    font-size: 3.5em;
     font-weight: bold;
     border-bottom: solid 2px lightcoral;
     padding-bottom: .5em;
@@ -31,18 +51,8 @@
     width: 98%;
   }
 
-  button {
-    cursor: pointer;
+  span {
     color: lightcoral;
-    height: 3.5em;
-    margin: 1em;
-    width: 28%
-  }
-
-  button:hover {
-    border-color: black;
-    color: black;
-    background-color: lightcoral;
   }
 
 </style>


### PR DESCRIPTION
## What does this PR do?
- Adds `WordBtn` component 
- Adds second fetch call
- Adds dispatch to `getNextSynonym`
- Functionality for the new set of btns to be displayed
- Styling for btns has been added along with some cleanup styling

## How to test?
- Pull down `second-fetch`
- Run `npm run dev`
- Load up the app and search some words

## Issues:
- This PR should close #9 
- The board is up to date

## Screenshots:
![Screen Shot 2020-03-02 at 5 32 28 PM](https://user-images.githubusercontent.com/48968224/75731033-cc00f800-5cab-11ea-9c30-75de2d1f28da.png)

## Notes:
- Next up is to add a loading component 
- Currently the fetch is repeated in a different file, this is a good place for a refactor once MVP is met.

Thanks!